### PR TITLE
Fix slug regeneration when updating blog posts

### DIFF
--- a/AspireBlazorBlog.ApiService/Services/BlogPostService.cs
+++ b/AspireBlazorBlog.ApiService/Services/BlogPostService.cs
@@ -74,6 +74,9 @@ public class BlogPostService : IBlogPostService
             return null;
         }
 
+        // Check if the title is actually changing before we overwrite it
+        var titleChanged = existingPost.Title != blogPost.Title;
+
         // Update only allowed fields
         existingPost.Title = blogPost.Title;
         existingPost.Content = blogPost.Content;
@@ -81,10 +84,10 @@ public class BlogPostService : IBlogPostService
         existingPost.UpdatedAt = DateTime.UtcNow;
 
         // Regenerate slug if title changed
-        if (existingPost.Title != blogPost.Title)
+        if (titleChanged)
         {
             existingPost.Slug = GenerateSlug(blogPost.Title);
-            
+
             // Ensure uniqueness
             var slugBase = existingPost.Slug;
             var counter = 1;

--- a/AspireBlazorBlog.Tests/AspireBlazorBlog.Tests.csproj
+++ b/AspireBlazorBlog.Tests/AspireBlazorBlog.Tests.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.Testing" Version="9.3.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"/>
         <PackageReference Include="xunit.v3" Version="2.0.0"/>
@@ -19,6 +20,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\AspireBlazorBlog.AppHost\AspireBlazorBlog.AppHost.csproj"/>
+        <ProjectReference Include="..\AspireBlazorBlog.ApiService\AspireBlazorBlog.ApiService.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/AspireBlazorBlog.Tests/BlogPostServiceTests.cs
+++ b/AspireBlazorBlog.Tests/BlogPostServiceTests.cs
@@ -1,0 +1,50 @@
+using AspireBlazorBlog.ApiService.Data;
+using AspireBlazorBlog.ApiService.Models;
+using AspireBlazorBlog.ApiService.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace AspireBlazorBlog.Tests;
+
+public class BlogPostServiceTests
+{
+    [Fact]
+    public async Task UpdatePostAsync_RegeneratesSlug_WhenTitleChanges()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<BlogDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new BlogDbContext(options);
+        var logger = new LoggerFactory().CreateLogger<BlogPostService>();
+        var service = new BlogPostService(context, logger);
+
+        var post = new BlogPost
+        {
+            Id = Guid.NewGuid(),
+            Title = "Original Title",
+            Content = "Content",
+            Summary = "Summary",
+            Slug = "original-title",
+            CreatedAt = DateTime.UtcNow
+        };
+        context.BlogPosts.Add(post);
+        await context.SaveChangesAsync();
+
+        var update = new BlogPost
+        {
+            Title = "New Title",
+            Content = "Content",
+            Summary = "Summary"
+        };
+
+        // Act
+        var result = await service.UpdatePostAsync(post.Id, update);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("new-title", result!.Slug);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure BlogPostService regenerates slug when title changes
- add xUnit test verifying slug is updated

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954e52816c832ea0e107b4fd89f0f0